### PR TITLE
Platforms.cs

### DIFF
--- a/src/GameHook.Application/Platforms.cs
+++ b/src/GameHook.Application/Platforms.cs
@@ -47,7 +47,7 @@ namespace GameHook.Application
         public MemoryAddressBlock[] Ranges { get; } = new List<MemoryAddressBlock>()
         {
             // new PlatformRange("BIOS",  0x00000000, 0x00003FF0),
-            new MemoryAddressBlock(0, "Partial EWRAM", 0x02023000, 0x02023000 + 9999),
+            new MemoryAddressBlock(0, "Partial EWRAM", 0x02020000, 0x02020000 + 9999, 0x03000000 + 9999, 0x04000000 + 300),
             // new PlatformRange("IWRAM", 0x03000000, 0x03007FF0),
         }.ToArray();
     }


### PR DESCRIPTION
Access to DMA pointers required
Adjust initial block: 0x02020000 + 1FFFF (131071 dec) - not sure if the + 9999 syntax is hex or dec, I'll let you adjust it
Add another block: 0x03000000 + 9999(hex)
Add a final smaller block: 0x0400000 + 300(hex)

This will expose nearly everything required (that I know of right now)